### PR TITLE
Fix build

### DIFF
--- a/lib/pngcrush.js
+++ b/lib/pngcrush.js
@@ -9,7 +9,7 @@ var options = {
   path: path.join(__dirname, '../vendor'),
   url: 'https://raw.github.com/1000ch/node-pngcrush-bin/master/vendor/pngcrush',
   src: 'http://downloads.sourceforge.net/project/pmt/pngcrush/1.7.72/pngcrush-1.7.72.zip',
-  buildScript: 'make && mv ./pngcrush ' + path.join(__dirname, '../vendor'),
+  buildScript: 'make && mv ./pngcrush ' + path.join(__dirname, '../vendor/pngcrush'),
   platform: {
     osx: {
       url: 'https://raw.github.com/1000ch/node-pngcrush-bin/master/vendor/osx/pngcrush'


### PR DESCRIPTION
Currently it moves pngcrush to the root path and renames it to `vendor` which is kinda bad.
