### PR TITLE
Bump pngcrush version to 1.7.82

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,7 @@ var pkg = require('../package.json');
  * Variables
  */
 
-var BIN_VERSION = '1.7.80';
+var BIN_VERSION = '1.7.82';
 var BASE_URL = 'https://raw.githubusercontent.com/imagemin/pngcrush-bin/v' + pkg.version + '/vendor/';
 
 /**


### PR DESCRIPTION
1.7.80 is no longer available at the default path, so use the latest version.

Fixes #7.
