### PR TITLE
Bump pngcrush version to 1.7.83

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,7 @@ var pkg = require('../package.json');
  * Variables
  */
 
-var BIN_VERSION = '1.7.82';
+var BIN_VERSION = '1.7.83';
 var BASE_URL = 'https://raw.githubusercontent.com/imagemin/pngcrush-bin/v' + pkg.version + '/vendor/';
 
 /**


### PR DESCRIPTION
1.7.82 is no longer available on the default path. Bumps version to 1.7.83.