### PR TITLE
Fixed soundforge version

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -11,7 +11,7 @@ bin.run(['-version'], function (err) {
 		log.info('compiling from source');
 
 		var builder = new BinBuild()
-			.src('http://downloads.sourceforge.net/project/pmt/pngcrush/1.7.87/pngcrush-1.7.87.zip')
+			.src('http://downloads.sourceforge.net/project/pmt/pngcrush/1.8.0/pngcrush-1.8.0.zip')
 			.cmd('mkdir -p ' + bin.dest())
 			.cmd('make && mv ' + bin.use() + ' ' + bin.path());
 

--- a/test/test.js
+++ b/test/test.js
@@ -22,7 +22,7 @@ afterEach(function () {
 
 it('rebuild the pngcrush binaries', function (cb) {
 	new BinBuild()
-		.src('http://downloads.sourceforge.net/project/pmt/pngcrush/1.7.87/pngcrush-1.7.87.zip')
+		.src('http://downloads.sourceforge.net/project/pmt/pngcrush/1.8.0/pngcrush-1.8.0.zip')
 		.cmd('mkdir -p ' + tmp)
 		.cmd('make && mv pngcrush ' + path.join(tmp, 'pngcrush'))
 		.run(function (err) {


### PR DESCRIPTION
pngcrush no longer has version 1.7.87 on soundforge, therefore the build was failing. Updated to the latest release.